### PR TITLE
add sample code for COBOL interop with Python

### DIFF
--- a/pyzkiln_core/cobol/1.64cobol_to_64python/cobtest.cbl
+++ b/pyzkiln_core/cobol/1.64cobol_to_64python/cobtest.cbl
@@ -1,0 +1,14 @@
+      *Copyright IBM Corp. 2024.
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. "COBTEST".
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 pyrun PIC u(80) VALUE z'print("Hello, world")'.
+       PROCEDURE DIVISION.
+           CALL "Py_Initialize"
+           CALL "PyRun_SimpleString" USING
+           BY REFERENCE pyrun
+           END-CALL
+           CALL "Py_Finalize"
+
+           STOP RUN.

--- a/pyzkiln_core/cobol/1.64cobol_to_64python/run.sh
+++ b/pyzkiln_core/cobol/1.64cobol_to_64python/run.sh
@@ -1,0 +1,13 @@
+#Copyright IBM Corp. 2024.
+
+rm -f *.o *.x *.lst cobtest
+
+set -x
+set -e
+
+# Compile COBOL which embeds Python
+cob2 -q64 -comprc_ok=0 -q"list" -q"dll" -q"pgmname(longmixed)" cobtest.cbl -o cobtest ${PYTHON_PATH}/lib/libpython3.12.x
+
+# Run 
+# Expected outout is a simple message 'Hello world' printed out in the terminal
+./cobtest

--- a/pyzkiln_core/cobol/2.64python_to_64cobol/call_cobtest.py
+++ b/pyzkiln_core/cobol/2.64python_to_64cobol/call_cobtest.py
@@ -1,0 +1,11 @@
+#Copyright IBM Corp. 2024.
+
+import ctypes                          # ctypes: library used in Python to load functions from shared libraries
+mydll = ctypes.CDLL("./cobtest.so")    # CDLL loads the shared library into the variable mydll (cobtest.so - this file is created from compiling cobtest.cbl)
+
+# Set up the function argument and return types
+mydll.COBTEST.argtypes = [ctypes.c_int, ctypes.c_int]
+mydll.COBTEST.restype = ctypes.c_int
+
+f = mydll.COBTEST(5,6)
+print(f)                               # The expected output is the addition of the two paramters - hence in this case it will be 11

--- a/pyzkiln_core/cobol/2.64python_to_64cobol/cobtest.cbl
+++ b/pyzkiln_core/cobol/2.64python_to_64cobol/cobtest.cbl
@@ -1,0 +1,20 @@
+      *Copyright IBM Corp. 2024.
+       IDENTIFICATION DIVISION.                                   
+       PROGRAM-ID. 'COBTEST'.                                      
+       ENVIRONMENT DIVISION.                                      
+       CONFIGURATION SECTION.                                     
+       INPUT-OUTPUT SECTION.                                      
+       FILE-CONTROL.                                              
+       DATA DIVISION.                                             
+       FILE SECTION.                                              
+       WORKING-STORAGE SECTION.                                   
+       LINKAGE SECTION.                                           
+       01 PARAM1                    PIC S9(9) USAGE IS BINARY. 
+       01 PARAM2                    PIC S9(9) USAGE IS BINARY. 
+       01 RETCODE                   PIC S9(9) USAGE IS BINARY. 
+       PROCEDURE DIVISION USING BY VALUE PARAM1 
+                          BY VALUE PARAM2
+                          RETURNING RETCODE.                      
+           ADD PARAM1 to RETCODE
+           ADD PARAM2 to RETCODE
+           GOBACK.

--- a/pyzkiln_core/cobol/2.64python_to_64cobol/run.sh
+++ b/pyzkiln_core/cobol/2.64python_to_64cobol/run.sh
@@ -1,0 +1,13 @@
+#Copyright IBM Corp. 2024.
+
+# Clean up previous builds
+rm -f *.o *.so *.x *.lst
+
+set -x
+set -e
+
+# Build COBOL shared library
+cob2 -q64 -comprc_ok=0 -q"list" -q"dll" -q"pgmname(longmixed)" -bdll -qexportall cobtest.cbl -o cobtest.so
+
+# Run Python to call the 64bit COBOL
+python3 call_cobtest.py

--- a/pyzkiln_core/cobol/3.64python_to_31cobol/callcobol/setup.py
+++ b/pyzkiln_core/cobol/3.64python_to_31cobol/callcobol/setup.py
@@ -1,0 +1,24 @@
+#Copyright IBM Corp. 2024.
+
+import os
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext 
+from setuptools import setup 
+
+def main():
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    extension_path = os.path.join(dir_path, "src", "callcobol.c")
+
+    setup(
+        name="callcobol",
+        version="1.0.0",
+        ext_modules=[
+            Extension(
+                "callcobol",            # name
+                sources=[extension_path],   # path to extension
+            )
+        ],
+    )
+
+if __name__ == "__main__":
+    main()

--- a/pyzkiln_core/cobol/3.64python_to_31cobol/callcobol/src/callcobol.c
+++ b/pyzkiln_core/cobol/3.64python_to_31cobol/callcobol/src/callcobol.c
@@ -1,0 +1,157 @@
+//Copyright IBM Corp. 2024.
+
+#include <Python.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <__le_cwi.h>
+#include <unistd.h>
+#include <signal.h>
+#include <iconv.h>
+#include <string.h>
+
+#define MLENGTH    10  /*length of module name string */
+#define FLENGTH    7   /*length of function name string */
+#define ALENGTH    8   /*length of target program argument */
+
+/* Fixed length structure RO31_CB */
+typedef struct RO31_cb{
+    unsigned int version;
+    unsigned int length;
+    unsigned int flags;
+    unsigned int off_module;
+    unsigned int off_func;
+    unsigned int off_args;
+    unsigned int dll_handle;
+    unsigned int func_desc;
+    unsigned int ret_gr_buffer[5];
+    unsigned int retcode;
+} RO31_cb;
+
+/* Module name to load */
+typedef struct RO31_module{
+    int length;
+    char module_name[MLENGTH];
+} RO31_module;
+
+/* Function name to query */
+typedef struct RO31_function{
+    int length;
+    char function_name[FLENGTH];
+} RO31_function;
+
+/* Arguments of the target program, R1 will point to content */
+/* when calling target program                               */
+typedef struct RO31_args{
+    int length;
+    int in1;
+    int in2;
+} RO31_args;
+
+int call_cobtest_31bit(int n1, int n2)
+{
+    RO31_cb* RO31_info;
+    RO31_args* RO31_args_p;
+    RO31_module* RO31_module_p;
+    RO31_function* RO31_func_p;
+    unsigned int ret;
+    unsigned int buf_len;
+
+    buf_len =  sizeof(RO31_cb) + MLENGTH + FLENGTH + ALENGTH + 12;
+    /* Get below the bar storage */
+    CELQGIPB(&buf_len,(void *)&RO31_info, &ret);
+
+    /* Init the RO31_INFO */
+    (*RO31_info).version = 1;
+    (*RO31_info).flags = 0xE0000000;
+    (*RO31_info).off_module = sizeof(RO31_cb);
+    (*RO31_info).off_func = (*RO31_info).off_module + MLENGTH + 4;
+    (*RO31_info).off_args = (*RO31_info).off_func + FLENGTH + 4;
+    (*RO31_info).length = sizeof(RO31_cb) + MLENGTH + FLENGTH + ALENGTH + 12;
+
+    RO31_args_p = (RO31_args*)(((intptr_t)RO31_info)+(*RO31_info).off_args);
+    RO31_module_p = (RO31_module*)(((intptr_t)RO31_info)+(*RO31_info).off_module);
+    RO31_func_p = (RO31_function*)(((intptr_t)RO31_info)+(*RO31_info).off_func);
+
+    RO31_module_p->length = MLENGTH;
+    RO31_func_p->length = FLENGTH;
+    RO31_args_p->length = ALENGTH;
+
+    RO31_args_p->in1 = n1;
+    RO31_args_p->in2 = n2;
+
+    iconv_t cd = iconv_open("IBM-1047", "UTF-8");
+
+    /* Setting up iconv module name conversion from utf to ebcdic */
+    char outbuf_mod[MLENGTH];
+    char *inptr_mod = "cobtest.so";
+    char *outptr_mod = outbuf_mod;
+    size_t insize_mod = MLENGTH;
+    size_t outsize_mod = MLENGTH;
+
+    size_t mod_res = iconv(cd, &inptr_mod, &insize_mod, &outptr_mod, &outsize_mod);
+    if (mod_res == (size_t)-1) {
+        perror("iconv");
+        return 0;
+    }
+    strcpy((*RO31_module_p).module_name, outbuf_mod);
+
+    /* Setting up iconv function name conversion from utf to ebcdic */
+    char outbuf_func[FLENGTH];
+    char *inptr_func = "COBTEST";
+    char *outptr_func = outbuf_func;
+    size_t insize_func = FLENGTH;
+    size_t outsize_func = FLENGTH;
+
+    size_t func_res = iconv(cd, &inptr_func, &insize_func, &outptr_func, &outsize_func);
+    if (func_res == (size_t)-1) {
+        printf("iconv had an unsuccesful attempt to convert function\n");
+        return 0;
+    }
+    strcpy((*RO31_func_p).function_name, outbuf_func);
+
+    iconv_close(cd);
+
+    printf("calling\n");
+    /* Call CEL4RO31()      */
+    CEL4RO31((void*)RO31_info);
+
+    /* Set return value     */
+    ret = RO31_info->ret_gr_buffer[0];
+    printf("called %d\n", ret);
+
+    return (int)ret;
+}
+
+static PyObject *call_cobtest(PyObject *self, PyObject *args){
+    int n1, n2;
+
+    if(!PyArg_ParseTuple(args, "ii", &n1, &n2)){
+        return NULL;
+    }
+
+    int ret = call_cobtest_31bit(n1, n2);
+    return Py_BuildValue("i", ret);
+}
+
+// module method definitions
+static PyMethodDef methods[] = {
+    {"call_cobtest", call_cobtest, METH_VARARGS, "returns sum of 4 inputs"},
+    {NULL, NULL, 0, NULL}
+};
+
+// module initialization function
+static struct PyModuleDef callcobol_exension_module = {
+    PyModuleDef_HEAD_INIT,
+    "callcobol",
+    NULL,
+    -1,
+    methods
+};
+
+// module initialization PyInit_<module name>(void)
+PyMODINIT_FUNC PyInit_callcobol(void)
+{
+    return PyModule_Create(&callcobol_exension_module);
+}
+

--- a/pyzkiln_core/cobol/3.64python_to_31cobol/cobtest.cbl
+++ b/pyzkiln_core/cobol/3.64python_to_31cobol/cobtest.cbl
@@ -1,0 +1,20 @@
+      *Copyright IBM Corp. 2024.
+       IDENTIFICATION DIVISION.                                   
+       PROGRAM-ID. 'COBTEST'.                                      
+       ENVIRONMENT DIVISION.                                      
+       CONFIGURATION SECTION.                                     
+       INPUT-OUTPUT SECTION.                                      
+       FILE-CONTROL.                                              
+       DATA DIVISION.                                             
+       FILE SECTION.                                              
+       WORKING-STORAGE SECTION.                                   
+       LINKAGE SECTION.                                           
+       01 PARAM1                    PIC S9(9) USAGE IS BINARY. 
+       01 PARAM2                    PIC S9(9) USAGE IS BINARY. 
+       01 RETCODE                   PIC S9(9) USAGE IS BINARY. 
+       PROCEDURE DIVISION USING BY VALUE PARAM1 
+                          BY VALUE PARAM2
+                          RETURNING RETCODE.                      
+           ADD PARAM1 to RETCODE
+           ADD PARAM2 to RETCODE
+           GOBACK.

--- a/pyzkiln_core/cobol/3.64python_to_31cobol/run.sh
+++ b/pyzkiln_core/cobol/3.64python_to_31cobol/run.sh
@@ -1,0 +1,19 @@
+#Copyright IBM Corp. 2024.
+
+rm -f *.o *.x *.so *.lst
+rm -rf venv callcobol/callcobol.egg-info callcobol/build callcobol/callcobol.cpython-312.x
+
+set -x
+set -e
+
+python3 -m venv venv
+source ./venv/bin/activate
+
+# Build our COBOL module
+cob2 -comprc_ok=0 -q"list" -q"dll" -q"pgmname(longmixed)" -bdll -qexportall cobtest.cbl -o cobtest.so
+
+# Build our Python package
+pip3 install -v ./callcobol
+
+# Call the 31bit COBOL from Python
+python3 -c "import callcobol; print(callcobol.call_cobtest(5,6))"

--- a/pyzkiln_core/cobol/4.31cobol_to_64python/cobtest.cbl
+++ b/pyzkiln_core/cobol/4.31cobol_to_64python/cobtest.cbl
@@ -1,0 +1,11 @@
+      *Copyright IBM Corp. 2024.
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. "COBTEST".
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       77  PGM-NAME                   PICTURE X(13).
+       LINKAGE SECTION.
+       PROCEDURE DIVISION.
+           MOVE "COBTEST2" to PGM-NAME.
+           CALL PGM-NAME.
+           STOP RUN.

--- a/pyzkiln_core/cobol/4.31cobol_to_64python/cobtest2.cbl
+++ b/pyzkiln_core/cobol/4.31cobol_to_64python/cobtest2.cbl
@@ -1,0 +1,12 @@
+      *Copyright IBM Corp. 2024.
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. "COBTEST2".
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       77  PGM-NAME                   PICTURE X(13).
+       LINKAGE SECTION.
+       PROCEDURE DIVISION.
+           DISPLAY "COBTEST2".
+           MOVE "SHAREDL" to PGM-NAME.
+           CALL PGM-NAME.
+           GOBACK.

--- a/pyzkiln_core/cobol/4.31cobol_to_64python/rem_dataset.sh
+++ b/pyzkiln_core/cobol/4.31cobol_to_64python/rem_dataset.sh
@@ -1,0 +1,3 @@
+#Copyright IBM Corp. 2024.
+
+tso "DELETE '${USER}.DATA.FILE'"

--- a/pyzkiln_core/cobol/4.31cobol_to_64python/run.sh
+++ b/pyzkiln_core/cobol/4.31cobol_to_64python/run.sh
@@ -1,0 +1,28 @@
+#Copyright IBM Corp. 2024.
+
+# Clean up directory
+rm -f *.o *.x CEE* *.lst cobtest cobtest2 SHAREDL
+
+set -x
+set -e
+
+# Compile COBOL 31bit program
+cob2 -g      -comprc_ok=0 -q"list"                                      cobtest.cbl -o cobtest
+
+# Compile COBOL 64bit program
+cob2 -g -q64 -comprc_ok=0 -q"list"                                -bdll cobtest2.cbl -o cobtest2
+
+# Compile COBOL 64bit shared lib
+cob2 -g -q64 -comprc_ok=0 -q"list" -q"dll" -q"pgmname(longmixed)" -bdll -qexportall sharedlib.cbl -o SHAREDL ${PYTHON_PATH}/lib/libpython3.12.x
+
+# Create a data set
+YOUR_DS=$USER.DATA.FILE
+tso "alloc DSN('${YOUR_DS}') NEW SPACE(10,10) DIR(10) UNIT(SYSDA) RECFM(U) BLKSIZE(4096) DSNTYPE(LIBRARY)"
+cp cobtest2 "//'$YOUR_DS(COBTEST2)'"
+cp SHAREDL  "//'$YOUR_DS(SHAREDL)'"
+
+# Run
+export STEPLIB=${YOUR_DS}:$STEPLIB
+export LIBPATH=$LIBPATH:.
+export _IGZ_RUNOPTS="AMODE3164"
+./cobtest

--- a/pyzkiln_core/cobol/4.31cobol_to_64python/sharedlib.cbl
+++ b/pyzkiln_core/cobol/4.31cobol_to_64python/sharedlib.cbl
@@ -1,0 +1,20 @@
+      *Copyright IBM Corp. 2024.
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. 'SHAREDL'.
+       ENVIRONMENT DIVISION.
+       CONFIGURATION SECTION.
+       INPUT-OUTPUT SECTION.
+       FILE-CONTROL.
+       DATA DIVISION.
+       FILE SECTION.
+       WORKING-STORAGE SECTION.
+       01 pyrun PIC u(80) VALUE z'import zlib; import _curses'.
+       PROCEDURE DIVISION.
+           DISPLAY "SHAREDLIB".
+           CALL "Py_Initialize"
+           CALL "PyRun_SimpleString" USING
+           BY REFERENCE pyrun
+           END-CALL
+           CALL "Py_Finalize"
+           STOP RUN.
+

--- a/pyzkiln_core/cobol/LICENSE
+++ b/pyzkiln_core/cobol/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 IBM Corporation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pyzkiln_core/cobol/README
+++ b/pyzkiln_core/cobol/README
@@ -1,0 +1,19 @@
+## Overview
+This directory contains a set of test files designed to validate and explain COBOL to Python Communication. 
+The tests cover:
+-	64-bit COBOL to 64-bit Python
+-	64-bit Python to 64-bit COBOL
+-	64-bit Python to 31-bit COBOL
+-	31-bit COBOL to 64-bit Python
+
+Since Python on z/OS is structured around CPython, Python data types will be formatted through C datatypes before being sent to COBOL. 
+To better explain interoperability between C and COBOL please refer to: 
+https://www.ibm.com/docs/en/zos/2.5.0?topic=applications-communicating-between-c-cobol 
+
+## Usage
+1.	Open the env.setup file and follow the instruction inside to set up your environment, once completed run it with the command ". env.setup"
+2.	Cd into the sub-directory of interest (i.e "cd 1.64cobol_to_64python")
+3.	Run the "run.sh" shell script
+
+4.	(NOTE) When the test for 31-bit COBOL to 64-bit Python, "4.31cobol_to_64python" test is run, it creates a z/OS dataset that MUST BE DELETED before the test can be run again.
+	Please run the "rem_dataset.sh" script in the same sub-directory after running the test to delete the created dataset before re-running tests.

--- a/pyzkiln_core/cobol/env.setup
+++ b/pyzkiln_core/cobol/env.setup
@@ -1,0 +1,10 @@
+#Copyright IBM Corp. 2024.
+
+#Set the PYTHON_PATH to your local install of Python
+export PYTHON_PATH=/path/to/your/local/python/install
+
+# Add local install of python to PATH and LIBPATH
+export PATH=${PYTHON_PATH}/bin:$PATH
+export LIBPATH=${PYTHON_PATH}/lib:$LIBPATH
+
+export LIBPATH=$LIBPATH:.


### PR DESCRIPTION
PR contains four examples demonstrating interoperability between Python and COBOL. Examples cover scenarios such as 64-bit to 64-bit communication and 31-bit to 64-bit communication.