### PR TITLE
Add pandas sample for interoperability between python & COBOL

### DIFF
--- a/pyzkiln_core/cobol/5.pandas/cobtest.cbl
+++ b/pyzkiln_core/cobol/5.pandas/cobtest.cbl
@@ -1,0 +1,113 @@
+      * Copyright IBM Corp. 2024.
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. "PANDASREAD".
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       01 pandas-name         PIC U(16) VALUE Z'pandas'.
+       01 pandas-module-ptr   USAGE POINTER.
+
+       01 read-name           PIC U(16) VALUE Z'read_csv'.
+       01 read-csv-func       USAGE POINTER.
+       01 read-csv-args       USAGE POINTER.
+
+       01 builtin-ptr         USAGE POINTER.
+       01 print-name          PIC U(16) VALUE Z'print'.
+       01 print-function      USAGE POINTER.
+       01 print-args          USAGE POINTER.
+
+       01 csv-path            PIC U(16) VALUE Z'./test.csv'.
+       01 csv-path-ptr        USAGE POINTER.
+       01 pandas-csv-data-ptr USAGE POINTER.
+
+       PROCEDURE DIVISION.
+       MAIN-PARAGRAPH.
+      ** This program gives an example of how to import and call Python
+      *  packages, specifically using pandas. This program loads up a
+      *  ISO8859-1 encoded csv file named test.csv using Pandas, and
+      *  prints out its content. This is equivalent to the following
+      *  Python script:
+      *  
+      *  import pandas
+      *  csv_data = pandas.read_csv('test.csv')
+      *  print(csv_data)
+
+      ** Initialize the Python interpreter
+           CALL "Py_Initialize"
+
+      ** Import the pandas module
+           CALL "PyImport_ImportModule" USING
+               pandas-name
+               RETURNING pandas-module-ptr
+           END-CALL
+
+           IF pandas-module-ptr EQUAL null
+               DISPLAY u'Failed to import pandas'
+               GOBACK
+           END-IF
+
+      ** Get read_csv function from pandas
+           CALL "PyObject_GetAttrString" USING
+               BY VALUE pandas-module-ptr
+               BY REFERENCE read-name
+               RETURNING read-csv-func
+           END-CALL
+
+      ** Create a tuple for calling read_csv - pandas.read_csv(path)
+           CALL "PyTuple_New" USING
+               BY VALUE 1
+               RETURNING read-csv-args
+           END-CALL
+
+      ** Get a Python UTF-8 Object for the path to the csv file
+           CALL "PyUnicode_FromString" USING
+               BY REFERENCE csv-path
+               RETURNING csv-path-ptr
+           END-CALL
+
+      ** Add the path to our tuple
+           CALL "PyTuple_SetItem" USING
+               BY VALUE read-csv-args
+               BY VALUE 0
+               BY VALUE csv-path-ptr
+           END-CALL
+
+      ** Call pandas.read_csv
+           CALL "PyObject_CallObject" USING
+               BY VALUE read-csv-func
+               BY VALUE read-csv-args
+               RETURNING pandas-csv-data-ptr
+           END-CALL
+
+      ** Get Pythons builtin print function
+           CALL "PyEval_GetBuiltins"
+               RETURNING builtin-ptr
+           END-CALL
+
+           CALL "PyDict_GetItemString" USING
+               BY VALUE builtin-ptr
+               BY REFERENCE print-name
+               RETURNING print-function
+           END-CALL
+
+      ** Create new tuple to call print with
+           CALL "PyTuple_New" USING
+               BY VALUE 1
+               RETURNING print-args
+           END-CALL
+
+      ** Add our pandas csv object 
+           CALL "PyTuple_SetItem" USING
+               BY VALUE print-args
+               BY VALUE 0
+               BY VALUE pandas-csv-data-ptr
+           END-CALL
+
+      ** Call print(csv)
+           CALL "PyObject_CallObject" USING
+               BY VALUE print-function
+               BY VALUE print-args
+           END-CALL
+
+      ** Shut down the Python interpreter
+           CALL "Py_Finalize"
+           STOP RUN.

--- a/pyzkiln_core/cobol/5.pandas/input.csv
+++ b/pyzkiln_core/cobol/5.pandas/input.csv
@@ -1,0 +1,3 @@
+col1,col2,col3
+a,b,c
+d,e,f

--- a/pyzkiln_core/cobol/5.pandas/run.sh
+++ b/pyzkiln_core/cobol/5.pandas/run.sh
@@ -1,0 +1,13 @@
+# Copyright IBM Corp. 2024.
+
+rm -f *.o *.x *.lst cobtest
+
+set -x
+set -e
+
+# Compile COBOL which embeds Python
+cob2 -q64 -g -comprc_ok=0 -q"list" -q"dll" -q"pgmname(longmixed)" cobtest.cbl -o cobtest ${PYTHON_PATH}/lib/libpython3.12.x
+
+# Run 
+# Expected output is the content of the file input.csv
+./cobtest

--- a/pyzkiln_core/cobol/README
+++ b/pyzkiln_core/cobol/README
@@ -5,6 +5,7 @@ The tests cover:
 -	64-bit Python to 64-bit COBOL
 -	64-bit Python to 31-bit COBOL
 -	31-bit COBOL to 64-bit Python
+-	64-bit COBOL to 64-bit Python - using Pandas
 
 Since Python on z/OS is structured around CPython, Python data types will be formatted through C datatypes before being sent to COBOL. 
 To better explain interoperability between C and COBOL please refer to: 
@@ -17,3 +18,4 @@ https://www.ibm.com/docs/en/zos/2.5.0?topic=applications-communicating-between-c
 
 4.	(NOTE) When the test for 31-bit COBOL to 64-bit Python, "4.31cobol_to_64python" test is run, it creates a z/OS dataset that MUST BE DELETED before the test can be run again.
 	Please run the "rem_dataset.sh" script in the same sub-directory after running the test to delete the created dataset before re-running tests.
+5.	(NOTE) For the sample **5.pandas** to run, the Python package Pandas must be installed into your Python environment. Pandas is available to install on the [Python AI Toolkit for IBM z/OS](https://ibm-z-oss-oda.github.io/python_ai_toolkit_zos). If this package is installed into a venv or elsewhere, you must export the environment variable PYTHONPATH=<path_to_your_packages_location>


### PR DESCRIPTION
This adds a more detailed example of using Pythons C API from COBOL to use a package installed from the Python AI Toolkit for IBM z/OS, specifically pandas. It loads up a csv file with pandas and prints out its contents. 